### PR TITLE
Update pytz to 2020.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-pytz==2019.3  # https://github.com/stub42/pytz
+pytz==2020.1  # https://github.com/stub42/pytz
 awesome-slugify==1.6.5  # https://github.com/dimka665/awesome-slugify
 Pillow==7.1.2  # https://github.com/python-pillow/Pillow
 argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi


### PR DESCRIPTION
This PR updates [pytz](https://pythonhosted.org/pytz/) from **2019.3** to **2020.1**.