### PR TITLE
Update django-allauth to 0.44.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ redis>=2.10.5  # https://github.com/antirez/redis
 django==2.2.19  # pyup: < 3.0  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
-django-allauth==0.42.0  # https://github.com/pennersr/django-allauth
+django-allauth==0.44.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.9.2  # https://github.com/django-crispy-forms/django-crispy-forms
 django-redis==4.12.1  # https://github.com/niwinz/django-redis
 


### PR DESCRIPTION
Update [django-allauth](https://pypi.org/project/django-allauth/) from **0.42.0** to **0.44.0**.