### PR TITLE
Update django-model-utils to 4.1.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ redis>=2.10.5  # https://github.com/antirez/redis
 # ------------------------------------------------------------------------------
 django==2.2.19  # pyup: < 3.0  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
-django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
+django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.44.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.9.2  # https://github.com/django-crispy-forms/django-crispy-forms
 django-redis==4.12.1  # https://github.com/niwinz/django-redis


### PR DESCRIPTION
Update [django-model-utils](https://pypi.org/project/django-model-utils/) from **4.0.0** to **4.1.1**.