### PR TITLE
Update pytz to 2021.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-pytz==2020.1  # https://github.com/stub42/pytz
+pytz==2021.1  # https://github.com/stub42/pytz
 awesome-slugify==1.6.5  # https://github.com/dimka665/awesome-slugify
 Pillow==8.1.2  # https://github.com/python-pillow/Pillow
 argon2-cffi==20.1.0  # https://github.com/hynek/argon2_cffi


### PR DESCRIPTION
Update [pytz](https://pypi.org/project/pytz/) from **2020.1** to **2021.1**.