### PR TITLE
Update django-redis to 5.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.44.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.11.2  # https://github.com/django-crispy-forms/django-crispy-forms
-django-redis==4.12.1  # https://github.com/niwinz/django-redis
+django-redis==5.0.0  # https://github.com/niwinz/django-redis
 
 # Django REST Framework
 djangorestframework==3.12.4  # https://github.com/encode/django-rest-framework


### PR DESCRIPTION
Update [django-redis](https://pypi.org/project/django-redis/) from **4.12.1** to **5.0.0**.