### PR TITLE
Update django-crispy-forms from 1.11.2 to 1.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ django==2.2.24  # pyup: < 3.0  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.44.0  # https://github.com/pennersr/django-allauth
-django-crispy-forms==1.11.2  # https://github.com/django-crispy-forms/django-crispy-forms
+django-crispy-forms==1.12.0  # https://github.com/django-crispy-forms/django-crispy-forms
 django-redis==5.0.0  # https://github.com/niwinz/django-redis
 
 # Django REST Framework


### PR DESCRIPTION
Update [django-crispy-forms](https://pypi.org/project/django-crispy-forms/) from **1.11.2** to **1.12.0**.